### PR TITLE
Don't overwrite user-supplied path

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ function pbjs(o) {
     }, o);
 
     return through.obj(function(file, enc, cb) {
-        console.log(file.base);
 
         if (file.isNull()) {
             cb(null, file);
@@ -38,7 +37,8 @@ function pbjs(o) {
 
         if(file.isBuffer()) {
 
-            var callOptions = extend({}, options, {path:[file.base]});
+            var callOptions = extend({}, options)
+            callOptions.path.push(file.base)
 
             var builder = sources[options.source]([file.history[0]], callOptions);
             file.contents = new Buffer(targets[options.target](builder, callOptions));


### PR DESCRIPTION
When a path is given in the input options, it is overwritten.  This patch fixes that by adding `file.base` to the path instead of replacing it.  It makes it possible for the user to configure the path where to look for proto files for imports when it differs from the input file.